### PR TITLE
Mesen 2 memory read fix

### DIFF
--- a/nestrischamps/emus/mesen.lua
+++ b/nestrischamps/emus/mesen.lua
@@ -1,7 +1,7 @@
 memory = {}
 
 function memory.readbyte(address)
-    return emu.read(address, emu.memType.nesDebug)
+    return emu.read(address, emu.memType.nesDebug or emu.memType.cpuDebug) -- handle constants for both mesen 2 and 1
 end
 
 function memory.readbyterange(address, bytes)


### PR DESCRIPTION
Fixed Mesen 2 connector by changing the memory.readByte to check emu.memType.nesDebug instead of emu.memType.cpuDebug