### PR TITLE
feat: more robust detection of  game start

### DIFF
--- a/nestrischamps.lua
+++ b/nestrischamps.lua
@@ -68,11 +68,8 @@ function newGameStarted()
 end
 
 
-local DELAY_NEW_GAME_NUM_FRAMES = 5 -- num frames to wait before starting new game
-
 local previousPieceState = -1
 local previousGameState = -1
-local numPendingFrames = -1
 
 playfield.initialize()
 frameManager.update(0, 0)
@@ -87,20 +84,9 @@ function loop()
 
     if gameState == 4 then --ingame, rocket, highscoreentry
         if previousGameState ~= 4 then -- possibly just started a game
-            if numPendingFrames < 0 then
-                -- Kinda gross delay before starting a new game :'(
-                -- 1 frame delay is needed because gameState changes before the game data are reset
-                -- We need to avoid sending one frame of old game data into the new game
-                numPendingFrames = DELAY_NEW_GAME_NUM_FRAMES
-            end
-
-            numPendingFrames = numPendingFrames - 1
-
-            if numPendingFrames < 0 then
-                -- delay elapsed, start a new game
+            if (getGameModeState() == 1) then -- new game is only ready when gameModeState transisions to 1
                 newGameStarted()
             else
-                -- delay ongoing, don't do anything
                 return
             end
         end

--- a/nestrischamps/getters.lua
+++ b/nestrischamps/getters.lua
@@ -6,6 +6,10 @@ function getGameState() -- gameState is a global thing for which menu/demo/gamep
     return memory.readbyte(0x00C0)
 end
 
+function getGameModeState() -- gameModeState turns to 1 in a new game
+    return memory.readbyte(0x00A7)
+end
+
 function getScore()
 	local is_gym_v5 = memory.readbyterange(0x075B, 5) == "T-GYM"
 	if is_gym_v5 then


### PR DESCRIPTION
## Context

After the [previous PR](https://github.com/Stabyourself/nestrischamps-emulator-connector/pull/10) increased the startup delay on a new game (to make sure the connector isn't sending old game data into the new game), we have received [a report](https://discord.com/channels/817528744565932043/875591588359831602/1419349746052628624) that the 5 frames delay doesn't seem to be consistent enough.

> I did 5 for a bit but I'm not sure it was working. I moved it up to 10 with some success


## Approach

User @zohassadar mentioned that after `gameMode` transitions to `4`, waiting for `gameModeState` to transision to `1` will ensure that all game variables are initialized properly.

Tested working on Mesen 2.1.1 on Win 11 with:
* Vanilla rom A type games
* Vanilla rom B type games
* GymV6 rom normal mode
* GymV6 rom transition mode
* GymV6 rom seed mode

